### PR TITLE
Add extend-expect.js

### DIFF
--- a/extend-expect.d.ts
+++ b/extend-expect.d.ts
@@ -1,0 +1,18 @@
+declare namespace jest {
+  interface Matchers<R, T> {
+    toBeObservable(): R
+    toBeProperty(): R
+    toBeStream(): R
+    toBePool(): R
+    toBeActiveObservable(): R
+    toEmit<V, E>(events: import('kefir-test-utils').Event<V, E>[], cb?: () => void): R
+    toEmitInTime<V, E>(
+      events: import('kefir-test-utils').EventWithTime<V, E>[],
+      cb?: (tick: (s: number) => void, clock: import('lolex').Clock) => void,
+      opts?: {reverseSimultaneous?: boolean; timeLimit?: number}
+    ): R
+    toFlowErrors<V, E>(source?: import('kefir').Observable<V, E>): R
+  }
+}
+
+declare var KTU: import('kefir-test-utils').Helpers

--- a/extend-expect.js
+++ b/extend-expect.js
@@ -1,0 +1,6 @@
+const Kefir = require('kefir')
+const jestPlugin = require('jest-kefir').default
+
+const {extensions, ...helpers} = jestPlugin(Kefir)
+expect.extend(extensions)
+global.KTU = helpers

--- a/extend-expect.test-d.ts
+++ b/extend-expect.test-d.ts
@@ -1,0 +1,23 @@
+import {expectType} from 'tsd'
+import Kefir from 'kefir'
+import './extend-expect'
+import {Helpers} from 'kefir-test-utils'
+
+expectType<void>(expect(1).toBeObservable())
+expectType<void>(expect(1).toBeProperty())
+expectType<void>(expect(1).toBeStream())
+expectType<void>(expect(1).toBePool())
+expectType<void>(expect(1).toBeActiveObservable())
+expectType<void>(expect(1).toEmit([KTU.value('string')], () => {}))
+expectType<void>(
+  expect(1).toEmitInTime(
+    [[10, KTU.value('string')]],
+    (tick, clock) => {
+      tick(10)
+      clock.runAll()
+    },
+    {reverseSimultaneous: true, timeLimit: 1000}
+  )
+)
+expectType<void>(expect(1).toFlowErrors(new Kefir.Observable()))
+expectType<Helpers>(KTU)

--- a/jest-kefir.test-d.ts
+++ b/jest-kefir.test-d.ts
@@ -1,7 +1,7 @@
 import {expectType} from 'tsd'
 import Kefir from 'kefir'
 import createHelpers from '.'
-import { Helpers } from 'kefir-test-utils'
+import {Helpers} from 'kefir-test-utils'
 
 const {extensions, ...helpers} = createHelpers(Kefir)
 

--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "build": "babel src -d dist",
     "prepublishOnly": "npm test && npm run build",
-    "fmt": "prettier src/*.js test/*.js jest-kefir.d.ts --write",
+    "fmt": "prettier src/*.js test/*.js *.*d.ts extend-expect.js --write",
     "test": "npm run build && npm run test:fmt && npm run test:ts && npm run test:unit",
-    "test:fmt": "prettier src/*.js test/*.js jest-kefir.d.ts --check",
+    "test:fmt": "prettier src/*.js test/*.js *.*d.ts extend-expect.js --check",
     "test:ts": "tsd",
     "test:unit": "jest"
   },
@@ -18,7 +18,7 @@
     "src",
     "jest-kefir.d.ts",
     "extend-expect.js",
-    "extend-expect.d,ts"
+    "extend-expect.d.ts"
   ],
   "keywords": [
     "kefir",
@@ -33,8 +33,8 @@
   },
   "homepage": "https://github.com/kefirjs/jest-kefir#readme",
   "dependencies": {
-    "@types/jest": "^24.0.23",
-    "@types/kefir": "^3.8.0",
+    "@types/jest": "^24.0.0",
+    "@types/kefir": "^3.0.0",
     "@types/lolex": "^2.0.0",
     "@types/node": "^12.12.0",
     "jest-diff": "^24.0.0",

--- a/test/jest-kefir.spec.js
+++ b/test/jest-kefir.spec.js
@@ -1,9 +1,6 @@
-import jestKefir from '../src'
-import Kefir from 'kefir'
+import '../extend-expect'
 
-const {extensions, prop, stream, pool, activate, deactivate, value, error, end, send} = jestKefir(Kefir)
-
-expect.extend(extensions)
+const {prop, stream, pool, activate, deactivate, value, error, end, send} = KTU
 
 describe('jest-kefir', () => {
   describe('toBeObservable', () => {


### PR DESCRIPTION
This can be required into the test environment to extend
the expect matcher with extra assertions, and make the
KTU namespace variable available globally. Update the
tests to use this method to ensure it works.