### PR TITLE
Specify node version in package.json

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,10 @@
     [
       "@babel/preset-env",
       {
-        "modules": "umd"
+        "modules": "commonjs",
+        "targets": {
+          "node": "8"
+        }
       }
     ]
   ]

--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
     "url": "https://github.com/kefirjs/jest-kefir/issues"
   },
   "homepage": "https://github.com/kefirjs/jest-kefir#readme",
+  "engines" : {
+    "node" : ">=8"
+  },
   "dependencies": {
     "@types/jest": "^25.1.5",
     "@types/kefir": "^3.0.0",


### PR DESCRIPTION
Update the babel configuration to set this explicitly. This has always
been the supported version, given our test matrix, but this makes
it more explicit.