### PR TITLE
Remove lolex type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@types/jest": "^27.0.3",
         "@types/kefir": "^3.0.0",
-        "@types/lolex": "^2.0.0",
         "@types/node": "^14.0.1",
         "kefir-test-utils": "^1.1.1"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "dependencies": {
     "@types/jest": "^27.0.3",
     "@types/kefir": "^3.0.0",
-    "@types/lolex": "^2.0.0",
     "@types/node": "^14.0.1",
     "kefir-test-utils": "^1.1.1"
   },


### PR DESCRIPTION
I don't think we need this dependency since the correct lolex/fake-timers type is already added by kefir-test-utils, right?